### PR TITLE
Admin panel's yt-dl updater to use path in .env

### DIFF
--- a/youtube-dl-express-backend/routes/admin.route.js
+++ b/youtube-dl-express-backend/routes/admin.route.js
@@ -145,7 +145,7 @@ router.post('/youtube-dl/update', async (req, res) => {
 
     updating = true;
     try {
-        let updateProcess = spawnSync('youtube-dl', ['-U'], { encoding: 'utf-8' });
+        let updateProcess = spawnSync(path.basename(parsedEnv.YOUTUBE_DL_PATH), ['-U'], { encoding: 'utf-8' });
         if (updateProcess.status === 0) {
             let message = updateProcess.stdout.split(os.EOL);
             if (message[message.length - 1] === '') message.pop();

--- a/youtube-dl-express-backend/routes/admin.route.js
+++ b/youtube-dl-express-backend/routes/admin.route.js
@@ -145,7 +145,7 @@ router.post('/youtube-dl/update', async (req, res) => {
 
     updating = true;
     try {
-        let updateProcess = spawnSync(path.basename(parsedEnv.YOUTUBE_DL_PATH), ['-U'], { encoding: 'utf-8' });
+        let updateProcess = spawnSync(parsedEnv.YOUTUBE_DL_PATH, ['-U'], { encoding: 'utf-8' });
         if (updateProcess.status === 0) {
             let message = updateProcess.stdout.split(os.EOL);
             if (message[message.length - 1] === '') message.pop();


### PR DESCRIPTION
Allows updating agents specified in the .env file which might have a different name to the hardcoded *youtube-dl* or not exist in `$PATH`